### PR TITLE
STYLE: Trim trailing whitespaces

### DIFF
--- a/CLI/CancellousAnalysis/CancellousAnalysis.py
+++ b/CLI/CancellousAnalysis/CancellousAnalysis.py
@@ -17,13 +17,13 @@ from MusculoskeletalAnalysisCLITools.density import densityMap
 # image: 3D image black and white of bone
 # mask: 3D labelmap of bone area, including cavities
 # threshold: The threshold for bone in the image. Any pixels with a higher value will be considered bone.
-# voxSize: The physical side length of the voxels, in mm 
+# voxSize: The physical side length of the voxels, in mm
 # slope, intercept and scale: parameters for density conversion
 # output: The name of the output directory
 def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, output):
     imgData=reader.readImg(inputImg)
     (_, maskData) = reader.readMask(inputMask)
-    
+
     (maskData, imgData) = crop(maskData, imgData)
     if np.count_nonzero(maskData) == 0:
          raise Exception("Segmentation mask is empty.")
@@ -53,7 +53,7 @@ def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, out
     print("""<filter-progress>{}</filter-progress>""".format(.60))
     sys.stdout.flush()
     # SMI
-    # Calculated by finding a 3d mesh, expanding the vertices by a small amount, and calculate a value based on the relative difference in surface area 
+    # Calculated by finding a 3d mesh, expanding the vertices by a small amount, and calculate a value based on the relative difference in surface area
     # Measures the characteristics of the shape; 0 for plate-like, 3 for rod-like, 4 for sphere-like
     # Surface area
     bS = boneMesh.area*(voxSize**2)
@@ -89,7 +89,7 @@ def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, out
     # connD gives an approximate measure of holes/connections per volume
     connD = (1-phi)/totalVolume
 
-    
+
 
 
     fPath = os.path.join(output, "cancellous.txt")

--- a/CLI/CorticalAnalysis/CorticalAnalysis.py
+++ b/CLI/CorticalAnalysis/CorticalAnalysis.py
@@ -17,10 +17,10 @@ from MusculoskeletalAnalysisCLITools.density import densityMap
 # image: 3D image black and white of bone
 # mask: 3D labelmap of bone area, including cavities
 # lower, upper: The thresholds for bone in the image. Any pixels with a value in the range will be considered bone.
-# voxSize: The physical side length of the voxels, in mm 
+# voxSize: The physical side length of the voxels, in mm
 # slope, intercept and scale: parameters for density conversion
 # output: The name of the output directory
-def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, output):   
+def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, output):
     imgData=reader.readImg(inputImg)
     (_, maskData) = reader.readMask(inputMask)
     (maskData, imgData) = crop(maskData, imgData)
@@ -83,7 +83,7 @@ def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, out
     # Density calculations are based on DICOM metadata
     density = densityMap(imgData, slope, intercept)
     tmd = np.mean(density[maskData])
-    
+
     fPath = os.path.join(output, "cortical.txt")
 
     header = [

--- a/CLI/DensityAnalysis/DensityAnalysis.py
+++ b/CLI/DensityAnalysis/DensityAnalysis.py
@@ -14,7 +14,7 @@ import MusculoskeletalAnalysisCLITools.reader as reader
 # Performs analysis on cortical bone
 # image: 3D image black and white of bone
 # mask: 3D labelmap of bone area, including cavities
-# voxSize: The physical side length of the voxels, in mm 
+# voxSize: The physical side length of the voxels, in mm
 # slope, intercept and scale: parameters of the equation for converting image values to mgHA/ccm
 # output: The name of the output directory
 def main(inputImg, inputMask, voxSize, slope, intercept, name, output):
@@ -94,7 +94,7 @@ def main(inputImg, inputMask, voxSize, slope, intercept, name, output):
         stdDensity,
         minDensity,
         maxDensity
-    ] 
+    ]
     writeReport(fPath, header, data)
 
 

--- a/CLI/IntervertebralAnalysis/IntervertebralAnalysis.py
+++ b/CLI/IntervertebralAnalysis/IntervertebralAnalysis.py
@@ -10,7 +10,7 @@ from MusculoskeletalAnalysisCLITools.writeReport import writeReport
 import MusculoskeletalAnalysisCLITools.reader as reader
 from MusculoskeletalAnalysisCLITools.width import width
 
-def main(inputImg, inputMask1, inputMask2, voxSize, name, output):   
+def main(inputImg, inputMask1, inputMask2, voxSize, name, output):
     imgData=reader.readImg(inputImg)
     (_, maskData1) = reader.readMask(inputMask1)
     (_, maskData2) = reader.readMask(inputMask2)
@@ -22,7 +22,7 @@ def main(inputImg, inputMask1, inputMask2, voxSize, name, output):
     (maskData, npData, imgData) = crop(maskData, npData, imgData)
     if np.count_nonzero(maskData) == 0 or np.count_nonzero(npData) == 0:
          raise Exception("Segmentation mask is empty.")
-    
+
     volume = np.count_nonzero(maskData) * voxSize**3
     npVolume = np.count_nonzero(npData) * voxSize**3
     vr = npVolume/volume

--- a/CLI/MusculoskeletalAnalysisCLITools/fill.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/fill.py
@@ -15,7 +15,7 @@ def fill(mask, radius):
 
     # seed is a mask of all ones, except zero where mask has zeros on the edges
     seed[0,:] = mask[0,:]
-    seed[-1,:] = mask[-1,:]   
+    seed[-1,:] = mask[-1,:]
     seed[:,-1] = mask[:,-1]
     seed[:,0] = mask[:,0]
     # seed's zero areas are expanded to match mask's zeros

--- a/CLI/MusculoskeletalAnalysisCLITools/largestCC.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/largestCC.py
@@ -2,7 +2,7 @@ import numpy as np
 from skimage.measure import label
 
 # Takes a binary numpy array
-# Finds the largest connected component 
+# Finds the largest connected component
 # Returns the mask with only the largest component
 def largestCC(mask):
     # Creates a labelmap of the mask, where connected components have the same label

--- a/CLI/MusculoskeletalAnalysisCLITools/reader.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/reader.py
@@ -5,8 +5,8 @@ from nrrd import read
 # Converts slicer image and segmentation volumes into numpy format
 
 # readImg
-# Reads an image file as input, returns the image as a numpy array     
-def readImg(inputImg):   
+# Reads an image file as input, returns the image as a numpy array
+def readImg(inputImg):
     imgReader = sitk.ImageFileReader()
     imgReader.SetFileName(inputImg)
     image = imgReader.Execute()

--- a/CLI/MusculoskeletalAnalysisCLITools/shape.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/shape.py
@@ -1,7 +1,7 @@
 from skimage import measure
 from trimesh import base
 
-# Creates a triangular mesh shape using marching cubes algorithm 
+# Creates a triangular mesh shape using marching cubes algorithm
 def bWshape(shape):
     verts, face, normals, values = measure.marching_cubes(shape)
     mesh=base.Trimesh(vertices=verts, faces=face, vertex_normals=normals, validate=True)

--- a/CLI/MusculoskeletalAnalysisCLITools/thickness.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/thickness.py
@@ -10,7 +10,7 @@ def findSpheres(mask):
 
     a,b,c=np.nonzero(mask)
     order = np.argsort(dist[a,b,c])
-    
+
     for n in order:
         # For each point, find the thickness radius at that point from the distance map
         x=a[n]

--- a/CLI/MusculoskeletalAnalysisCLITools/width.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/width.py
@@ -37,16 +37,16 @@ def rotatingCaliper(pts):
     # Find the furthest point
     while crossProduct(hull[n - 1], hull[0], hull[(k + 1) % n]) > crossProduct(hull[n - 1], hull[0], hull[k]):
         k += 1
- 
+
     res = 0
- 
+
     # For each point between 0 and k find the opposite point j
     for i in range(k + 1):
         j = (i + 1) % n
         while crossProduct(hull[i], hull[(i + 1) % n], hull[(j + 1) % n]) > crossProduct(hull[i], hull[(i + 1) % n], hull[j]):
             j = (j + 1) % n
             res = max(res, math.sqrt((hull[i][0]-hull[j][0])**2+(hull[i][0]-hull[j][1])**2))
- 
+
     return res
 
 def edge(img):

--- a/Scripted/MusculoskeletalAnalysis/MusculoskeletalAnalysis.py
+++ b/Scripted/MusculoskeletalAnalysis/MusculoskeletalAnalysis.py
@@ -1,6 +1,6 @@
 import logging
 import os
-import time 
+import time
 import vtk
 import importlib
 
@@ -79,7 +79,7 @@ def registerSampleData():
         nodeNames='Cortical1'
     )
 
-   
+
     SampleData.SampleDataLogic.registerCustomSampleDataSource(
         # Category and sample name displayed in Sample Data module
         category='MusculoskeletalAnalysis',
@@ -97,7 +97,7 @@ def registerSampleData():
         # This node name will be used when the data set is loaded
         nodeNames='CorticalMask1'
     )
-    
+
     SampleData.SampleDataLogic.registerCustomSampleDataSource(
         # Category and sample name displayed in Sample Data module
         category='MusculoskeletalAnalysis',
@@ -228,7 +228,7 @@ def registerSampleData():
         # This node name will be used when the data set is loaded
         nodeNames='IntervertebralMask1'
     )
-    
+
 #
 # MusculoskeletalAnalysisWidget
 #
@@ -248,7 +248,7 @@ class MusculoskeletalAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservation
         self._parameterNode = None
         self._updatingGUIFromParameterNode = False
 
-    def setup(self):        
+    def setup(self):
         """
         Called when the user opens the module the first time and the widget is initialized.
         """
@@ -299,9 +299,9 @@ class MusculoskeletalAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservation
         self.ui.AnalysisProgress.hide()
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
-        
-        
-        
+
+
+
 
     def cleanup(self):
         """
@@ -372,9 +372,9 @@ class MusculoskeletalAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservation
         # Set default state for flags
         self._parameterNode.SetParameter("Analyzing", "False")
 
-        
-        
-        
+
+
+
 
 
     def setParameterNode(self, inputParameterNode):
@@ -468,7 +468,7 @@ class MusculoskeletalAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservation
             self.ui.applyButton.enabled = False
 
         # All the GUI updates are done
-        self._updatingGUIFromParameterNode = False       
+        self._updatingGUIFromParameterNode = False
 
     def inputVolumeChanged(self, event):
         """
@@ -510,14 +510,14 @@ class MusculoskeletalAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservation
         elif caller == 'SegmentNode':
             self._parameterNode.SetNodeReferenceID("SegmentNode", event.GetID())
         elif caller == 'Segment':
-            self._parameterNode.SetParameter("SegmentID", str(event))           
+            self._parameterNode.SetParameter("SegmentID", str(event))
         elif caller == 'DICOM' and event is not None:
             self._parameterNode.SetNodeReferenceID("DICOMNode", event.GetID())
         self._parameterNode.SetParameter("LowerThreshold", str(self.ui.thresholdSelector.lowerThreshold))
         self._parameterNode.SetParameter("UpperThreshold", str(self.ui.thresholdSelector.upperThreshold))
         self._parameterNode.SetParameter("Analysis", str(self.ui.analysisSelector.currentText))
-        self._parameterNode.SetParameter("UseAlt", str(self.ui.AlternateDICOMCheckBox.checked))     
-        self._parameterNode.SetParameter("UseMan", str(self.ui.ManualDICOMCheckBox.checked)) 
+        self._parameterNode.SetParameter("UseAlt", str(self.ui.AlternateDICOMCheckBox.checked))
+        self._parameterNode.SetParameter("UseMan", str(self.ui.ManualDICOMCheckBox.checked))
         self.setNumParameter("0018,0050", str(self.ui.voxelSizeLineEdit.text))
         self.setNumParameter("0029,1000", str(self.ui.scalingLineEdit.text))
         self.setNumParameter("0029,1004", str(self.ui.densitySlopeLineEdit.text))
@@ -550,14 +550,14 @@ class MusculoskeletalAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservation
         """
         with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
             # Compute output
-            self.logic.process(self._parameterNode.GetNodeReference("InputVolume"), self._parameterNode.GetNodeReference("SegmentNode"), self._parameterNode.GetParameter("SegmentID"), 
+            self.logic.process(self._parameterNode.GetNodeReference("InputVolume"), self._parameterNode.GetNodeReference("SegmentNode"), self._parameterNode.GetParameter("SegmentID"),
                                self.ui.thresholdSelector.lowerThreshold,  self.ui.thresholdSelector.upperThreshold, self.ui.analysisSelector.currentText, self.ui.outputDirectorySelector.currentPath,
-                               self.ui.AlternateDICOMCheckBox.checked, self._parameterNode.GetNodeReference("DICOMNode"), self.ui.ManualDICOMCheckBox.checked, 
-                               {'0018,0050':self.ui.voxelSizeLineEdit.text, '0029,1000':self.ui.scalingLineEdit.text, '0029,1004':self.ui.densitySlopeLineEdit.text, '0029,1005':self.ui.densityInterceptLineEdit.text, '0029,1006':self.ui.waterDensityLineEdit.text}, self)        
+                               self.ui.AlternateDICOMCheckBox.checked, self._parameterNode.GetNodeReference("DICOMNode"), self.ui.ManualDICOMCheckBox.checked,
+                               {'0018,0050':self.ui.voxelSizeLineEdit.text, '0029,1000':self.ui.scalingLineEdit.text, '0029,1004':self.ui.densitySlopeLineEdit.text, '0029,1005':self.ui.densityInterceptLineEdit.text, '0029,1006':self.ui.waterDensityLineEdit.text}, self)
         self.updateGUIFromParameterNode()
 
-            
-            
+
+
 
     # Updates
     def analysisUpdate(self, cliNode, event):
@@ -570,12 +570,12 @@ class MusculoskeletalAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservation
                 print("CLI execution failed: " + errorText)
             else:
                 # success
-                print("CLI execution succeeded.")    
+                print("CLI execution succeeded.")
             startTime=float(self._parameterNode.GetParameter("startTime"))
             stopTime = time.time()
             logging.info(f'Processing completed in {stopTime-startTime:.2f} seconds')
             # Clean up temp nodes
-            slicer.mrmlScene.RemoveNode(self._parameterNode.GetNodeReference("labelMap"))          
+            slicer.mrmlScene.RemoveNode(self._parameterNode.GetNodeReference("labelMap"))
             slicer.mrmlScene.RemoveNode(cliNode)
             self._parameterNode.SetParameter("Analyzing", "False")
             self.updateGUIFromParameterNode()
@@ -583,7 +583,7 @@ class MusculoskeletalAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservation
             self.ui.AnalysisProgress.setValue(cliNode.GetProgress())
 
 
-        
+
 
 
 #
@@ -626,7 +626,7 @@ class MusculoskeletalAnalysisLogic(ScriptedLoadableModuleLogic):
         if not inputVolume:
             raise ValueError("Input volume is invalid")
         if not mask or not maskLabel:
-            raise ValueError("Segment is invalid")       
+            raise ValueError("Segment is invalid")
         if altDICOM and not DICOMNode:
             raise ValueError("No DICOM source")
         if manDICOM and not all(DICOMOptions):
@@ -635,7 +635,7 @@ class MusculoskeletalAnalysisLogic(ScriptedLoadableModuleLogic):
         if not os.access(outputDirectory, os.W_OK):
             if not os.access(outputDirectory, os.F_OK):
                 # If directory doesn't exist try to create it
-                try: 
+                try:
                     os.makedirs(outputDirectory)
                     if not os.access(outputDirectory, os.W_OK):
                         raise ValueError("Output Directory is invalid")
@@ -647,7 +647,7 @@ class MusculoskeletalAnalysisLogic(ScriptedLoadableModuleLogic):
 
         startTime = time.time()
         logging.info('Processing started')
-        
+
         # Get mask segments
         if analysis == 'Intervertebral':
             maskLabel = maskLabel.strip('()')
@@ -669,7 +669,7 @@ class MusculoskeletalAnalysisLogic(ScriptedLoadableModuleLogic):
             maskArray.InsertNextValue(maskID)
             labelmap = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
             slicer.vtkSlicerSegmentationsModuleLogic.ExportSegmentsToLabelmapNode(mask, maskArray, labelmap, inputVolume)
-        
+
 
         # Get DICOM source
         if altDICOM:
@@ -687,7 +687,7 @@ class MusculoskeletalAnalysisLogic(ScriptedLoadableModuleLogic):
         voxelSize = self.getDICOMTag(dSource, '0018,0050')
 
         # Prepare parameters for the selected function
-        if analysis == "Cortical": 
+        if analysis == "Cortical":
             parameters = {"image":inputVolume, "mask":labelmap, "lowerThreshold":lowerThreshold, "upperThreshold":upperThreshold, "voxelSize":voxelSize, "slope":slope, "intercept":intercept, "inputName":inputVolume.GetName(), "output":outputDirectory}
             module=slicer.modules.corticalanalysis
             requirements = [('scipy', 'scipy'), ('skimage', 'scikit-image'), ('nrrd', 'pynrrd')]
@@ -715,9 +715,9 @@ class MusculoskeletalAnalysisLogic(ScriptedLoadableModuleLogic):
             source._parameterNode.SetParameter("Analyzing", "True")
             source._parameterNode.SetNodeReferenceID("labelmapNode", labelmap.GetID())
             source._parameterNode.SetParameter("startTime", str(startTime))
-            node.AddObserver('ModifiedEvent', source.analysisUpdate)   
-        slicer.cli.run(module=module, node=node, wait_for_completion=wait)   
-        
+            node.AddObserver('ModifiedEvent', source.analysisUpdate)
+        slicer.cli.run(module=module, node=node, wait_for_completion=wait)
+
 
     # Used to get dicom metadata from the volume
     # source: the volume node or DICOM dict
@@ -796,8 +796,8 @@ class MusculoskeletalAnalysisTest(ScriptedLoadableModuleTest):
         # Make sure the scene is clear before starting
         slicer.mrmlScene.Clear()
         registerSampleData()
-       
-        
+
+
         try:
             # Set test parameters
             inputVolume = SampleData.downloadSample('Cortical1')
@@ -808,20 +808,20 @@ class MusculoskeletalAnalysisTest(ScriptedLoadableModuleTest):
             analysis="Cortical"
             options = {"0018,0050":0.0073996, "0029,1000":4096,"0029,1004":365.712, "0029,1005":-199.725998, "0029,1006":0.4939}
             outputDirectory = os.path.expanduser("~\\Documents\\MusculoskeletalAnalysisTest")
-        
+
             self.delayDisplay('Loaded test data set')
             # Test the module logic
 
             logic = MusculoskeletalAnalysisLogic()
 
-        
+
             # Test cortical analysis
             logic.process(inputVolume, mask, maskLabel, lowerThreshold, upperThreshold, analysis, outputDirectory, manDICOM=True, DICOMOptions=options, wait=True)
             self.testFile(os.path.join(outputDirectory, "cortical.txt"), [str(date.today()), "Cortical1", 0.22723809679518692, 0.06294702323770145, 1079.7468139192893, 0.09759454038853543, 1.6929074569373408, 0.9198784024224288, 0.773029054514912, 0.48131583996128624, 0.0073996])
         finally:
             # Clean up nodes
             slicer.mrmlScene.Clear()
-        
+
         try:
             # Set test parameters
             inputVolume = SampleData.downloadSample('Cancellous1')
@@ -829,7 +829,7 @@ class MusculoskeletalAnalysisTest(ScriptedLoadableModuleTest):
             maskLabel = "Segment_1"
             lowerThreshold = 1500
             upperThreshold = 10000
-            analysis="Cancellous"      
+            analysis="Cancellous"
             self.delayDisplay('Loaded test data set')
             # Test cancellous analysis
             logic.process(inputVolume, mask, maskLabel, lowerThreshold, upperThreshold, analysis, outputDirectory, manDICOM=True, DICOMOptions=options, wait=True)
@@ -852,7 +852,7 @@ class MusculoskeletalAnalysisTest(ScriptedLoadableModuleTest):
             maskLabel = "'Segment_1, Segment_2'"
             lowerThreshold = 0
             upperThreshold = 0
-            analysis="Intervertebral"      
+            analysis="Intervertebral"
             self.delayDisplay('Loaded test data set')
             # Test cancellous analysis
             logic.process(inputVolume, mask, maskLabel, lowerThreshold, upperThreshold, analysis, outputDirectory, manDICOM=True, DICOMOptions=options, wait=True)
@@ -890,4 +890,4 @@ class MusculoskeletalAnalysisTest(ScriptedLoadableModuleTest):
             except ValueError:
                 # Checks that strings match
                 assert data[i] == testData[i], "Value for " + header[i] + ", " + testData[i] + ", doesn't match expected value " + str(data[i]) + "."
-        
+


### PR DESCRIPTION
Consistently avoiding trailing whitespaces is helpful to avoid "false differences" and ensure all diffing tools show the "real" changes by default.