### PR TITLE
Update readme and packaging fixes

### DIFF
--- a/CLI/CMakeLists.txt
+++ b/CLI/CMakeLists.txt
@@ -1,14 +1,14 @@
 #-----------------------------------------------------------------------------
 set(PYTHON_TOOLS
   MusculoskeletalAnalysisCLITools/__init__.py
+  MusculoskeletalAnalysisCLITools/crop.py
+  MusculoskeletalAnalysisCLITools/density.py
   MusculoskeletalAnalysisCLITools/fill.py
+  MusculoskeletalAnalysisCLITools/largestCC.py
+  MusculoskeletalAnalysisCLITools/reader.py
+  MusculoskeletalAnalysisCLITools/shape.py
   MusculoskeletalAnalysisCLITools/thickness.py
   MusculoskeletalAnalysisCLITools/writeReport.py
-  MusculoskeletalAnalysisCLITools/reader.py
-  MusculoskeletalAnalysisCLITools/crop.py
-  MusculoskeletalAnalysisCLITools/largestCC.py
-  MusculoskeletalAnalysisCLITools/shape.py
-  MusculoskeletalAnalysisCLITools/density.py
   )
 
 set(binary_dir "${CMAKE_BINARY_DIR}/${Slicer_CLIMODULES_BIN_DIR}")
@@ -31,6 +31,6 @@ ctkMacroCompilePythonScript(
     NO_INSTALL_SUBDIR
     )
 
-add_subdirectory(CorticalAnalysis)
 add_subdirectory(CancellousAnalysis)
+add_subdirectory(CorticalAnalysis)
 add_subdirectory(DensityAnalysis)

--- a/CLI/CMakeLists.txt
+++ b/CLI/CMakeLists.txt
@@ -8,6 +8,7 @@ set(PYTHON_TOOLS
   MusculoskeletalAnalysisCLITools/reader.py
   MusculoskeletalAnalysisCLITools/shape.py
   MusculoskeletalAnalysisCLITools/thickness.py
+  MusculoskeletalAnalysisCLITools/width.py
   MusculoskeletalAnalysisCLITools/writeReport.py
   )
 

--- a/CLI/CMakeLists.txt
+++ b/CLI/CMakeLists.txt
@@ -34,3 +34,4 @@ ctkMacroCompilePythonScript(
 add_subdirectory(CancellousAnalysis)
 add_subdirectory(CorticalAnalysis)
 add_subdirectory(DensityAnalysis)
+add_subdirectory(IntervertebralAnalysis)

--- a/CLI/CancellousAnalysis/CancellousAnalysis.py
+++ b/CLI/CancellousAnalysis/CancellousAnalysis.py
@@ -4,7 +4,6 @@ import sys
 import os
 from datetime import date
 import numpy as np
-from skimage import measure
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from MusculoskeletalAnalysisCLITools.crop import crop
 from MusculoskeletalAnalysisCLITools.thickness import findSpheres
@@ -21,6 +20,8 @@ from MusculoskeletalAnalysisCLITools.density import densityMap
 # slope, intercept and scale: parameters for density conversion
 # output: The name of the output directory
 def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, output):
+    from skimage import measure
+
     imgData=reader.readImg(inputImg)
     (_, maskData) = reader.readMask(inputMask)
     

--- a/CLI/CancellousAnalysis/CancellousAnalysis.py
+++ b/CLI/CancellousAnalysis/CancellousAnalysis.py
@@ -12,6 +12,27 @@ import MusculoskeletalAnalysisCLITools.reader as reader
 import MusculoskeletalAnalysisCLITools.shape as shape
 from MusculoskeletalAnalysisCLITools.density import densityMap
 
+
+OUTPUT_FIELDS = [
+    ("Date Analysis Performed", "The current date"),
+    ("Input Volume", "Name of the input volume"),
+    ("Total Volume (mm^3)", "The volume of the segmented area"),
+    ("Bone Volume (mm^3)", "The volume of cancellous bone in the segmented area, calculated using marching cubes"),
+    ("Bone Volume/Total Volume", "The fraction of the volume that is bone"),
+    ("Mean Trabecular Thickness (mm)", "The mean thickess of the bone, measured using largest sphere thickness, in milimeters"),
+    ("Trabecular Thickness Standard Deviation (mm)", "The standard deviation of the mean trabecular thickness"),
+    ("Mean Trabecular Spacing (mm)", "The mean thickness of the non area not containing bone in milimeters, measured using the same method as bone thickness."),
+    ("Trabecular Spacing Standard Deviation (mm)", "The standard deviation of the mean trabecular spacing"),
+    ("Trabecular Number", "Approximated as inverse of trabecular spacing"),
+    ("Structure Model Index", "A measurement of the trabecular shape. 0 is a plate, 3 is a rod, 4 is a sphere"),
+    ("Connectivity Density", "A measurement of the number of connections per volume, based on the Euler characteristic of the bone after removing isolated components and holes"),
+    ("Tissue Mineral Density(mgHA/cm^3)", "The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter"),
+    ("Voxel Dimension (mm)", "The side length of one voxel, measured in milimeters"),
+    ("Lower Threshold", "The lower threshold value for bone"),
+    ("Upper Threshold", "The upper threshold value for bone"),
+]
+
+
 # Performs analysis on cancellous bone
 # image: 3D image black and white of bone
 # mask: 3D labelmap of bone area, including cavities
@@ -95,24 +116,8 @@ def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, out
 
     fPath = os.path.join(output, "cancellous.txt")
 
-    header = [
-        'Date Analysis Performed',
-        'Input Volume',
-        'Total Volume (mm^3)',
-        'Bone Volume (mm^3)',
-        'Bone Volume/Total Volume',
-        'Mean Trabecular Thickness (mm)',
-        'Trabecular Thickness Standard Deviation (mm)',
-        'Mean Trabecular Spacing (mm)',
-        'Trabecular Spacing Standard Deviation (mm)',
-        'Trabecular Number',
-        'Structure Model Index',
-        'Connectivity Density',
-        'Tissue Mineral Density(mgHA/cm^3)',
-        'Voxel Dimension (mm)',
-        'Lower Threshold',
-        'Upper Threshold'
-    ]
+    header = [field[0] for field in OUTPUT_FIELDS]
+
     data = [
         date.today(),
         name,

--- a/CLI/CorticalAnalysis/CorticalAnalysis.py
+++ b/CLI/CorticalAnalysis/CorticalAnalysis.py
@@ -2,16 +2,21 @@
 
 import sys
 import os
-import numpy as np
 from datetime import date
+
+import numpy as np
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from MusculoskeletalAnalysisCLITools.crop import crop
-from MusculoskeletalAnalysisCLITools.thickness import findSpheres
-from MusculoskeletalAnalysisCLITools.fill import fill
-from MusculoskeletalAnalysisCLITools.writeReport import writeReport
-from MusculoskeletalAnalysisCLITools.largestCC import largestCC
-import MusculoskeletalAnalysisCLITools.reader as reader
-from MusculoskeletalAnalysisCLITools.density import densityMap
+from MusculoskeletalAnalysisCLITools import (
+    crop,
+    densityMap,
+    findSpheres,
+    fill,
+    largestCC,
+    readImg,
+    readMask,
+    writeReport,
+)
 
 
 OUTPUT_FIELDS = [
@@ -37,8 +42,8 @@ OUTPUT_FIELDS = [
 # slope, intercept and scale: parameters for density conversion
 # output: The name of the output directory
 def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, output):   
-    imgData=reader.readImg(inputImg)
-    (_, maskData) = reader.readMask(inputMask)
+    imgData = readImg(inputImg)
+    (_, maskData) = readMask(inputMask)
     (maskData, imgData) = crop(maskData, imgData)
     if np.count_nonzero(maskData) == 0:
          raise Exception("Segmentation mask is empty.")

--- a/CLI/CorticalAnalysis/CorticalAnalysis.py
+++ b/CLI/CorticalAnalysis/CorticalAnalysis.py
@@ -13,6 +13,22 @@ from MusculoskeletalAnalysisCLITools.largestCC import largestCC
 import MusculoskeletalAnalysisCLITools.reader as reader
 from MusculoskeletalAnalysisCLITools.density import densityMap
 
+
+OUTPUT_FIELDS = [
+    ("Date Analysis Performed", "The current date"),
+    ("Input Volume", "Name of the input volume"),
+    ("Mean Cortical Thickness (mm)", "The mean thickness of the bone, measured by largest sphere thickness, in milimeters"),
+    ("Cortical Thickness Standard Deviation (mm)", "The standard deviation of the above measurement"),
+    ("Tissue Mineral Density(mgHA/cm^3)", "The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter"),
+    ("Porosity", "The fraction of the bone area made up of pores"),
+    ("Total Area (mm^2)", "The area of the bone and medullary cavity. All areas are measured in average square milimeters per slice"),
+    ("Bone Area (mm^2)", "The area of the bone"),
+    ("Medullary Area (mm^2)", "The area of the medullary cavity"),
+    ("Polar Moment of Interia(mm^4)", "The moment of intertia around the z-axis, based on the shape of the mask. Measured in mm^4"),
+    ("Voxel Dimension (mm)", "The side length of one voxel, measured in milimeters"),
+]
+
+
 # Performs analysis on cortical bone
 # image: 3D image black and white of bone
 # mask: 3D labelmap of bone area, including cavities
@@ -86,19 +102,7 @@ def main(inputImg, inputMask, lower, upper, voxSize, slope, intercept, name, out
     
     fPath = os.path.join(output, "cortical.txt")
 
-    header = [
-        'Date Analysis Performed',
-        'Input Volume',
-        'Mean Cortical Thickness (mm)',
-        'Cortical Thickness Standard Deviation (mm)',
-        'Tissue Mineral Density(mgHA/cm^3)',
-        'Porosity',
-        'Total Area (mm^2)',
-        'Bone Area (mm^2)',
-        'Medullary Area (mm^2)',
-        'Polar Moment of Interia(mm^4)',
-        'Voxel Dimension (mm)'
-    ]
+    header = [field[0] for field in OUTPUT_FIELDS]
     data = [
         date.today(),
         name,

--- a/CLI/DensityAnalysis/DensityAnalysis.py
+++ b/CLI/DensityAnalysis/DensityAnalysis.py
@@ -11,6 +11,25 @@ from MusculoskeletalAnalysisCLITools.density import densityMap
 import MusculoskeletalAnalysisCLITools.reader as reader
 
 
+OUTPUT_FIELDS = [
+    ("Date Analysis Performed", "The current date"),
+    ("Input Volume", "Name of the input volume"),
+    ("Area by Slice", "The area of the segment in each slice of each slice"),
+    ("Mean Density by Slice", "The average density of the segmented area each slice"),
+    ("Standard Deviation of Density by Slice", "The standard deviation of the density of each slice"),
+    ("Min Density by Slice", "The lowest density in the segment of each slice"),
+    ("Max Density by Slice", "The highest density in the segment of each slice"),
+    ("Mean Area", "The mean area of the segment of all slices"),
+    ("Standard Deviation of Area", "The standard deviation of the segmented area of all slices"),
+    ("Min Area", "The area of the smallest segment slice"),
+    ("Max Area", "The area of the largest segment slice"),
+    ("Mean Density", "The average density of the entire segmented volume"),
+    ("Standard Deviation of Density", "The standard deviation of density of the segmented volume"),
+    ("Min Density", "The minimum density of the segmented volume"),
+    ("Max Density", "The maximum density of the segmented volume"),
+]
+
+
 # Performs analysis on cortical bone
 # image: 3D image black and white of bone
 # mask: 3D labelmap of bone area, including cavities
@@ -61,23 +80,8 @@ def main(inputImg, inputMask, voxSize, slope, intercept, name, output):
 
     fPath = os.path.join(output, "density.txt")
 
-    header = [
-        'Date Analysis Performed',
-        'Input Volume',
-        'Area by Slice',
-        'Mean Density by Slice',
-        'Standard Deviation of Density by Slice',
-        'Min Density by Slice',
-        'Max Density by Slice',
-        'Mean Area',
-        'Standard Deviation of Area',
-        'Min Area',
-        'Max Area',
-        'Mean Density',
-        'Standard Deviation of Density',
-        'Min Density',
-        'Max Density'
-    ]
+    header = [field[0] for field in OUTPUT_FIELDS]
+
     data = [
         date.today(),
         name,

--- a/CLI/DensityAnalysis/DensityAnalysis.py
+++ b/CLI/DensityAnalysis/DensityAnalysis.py
@@ -2,13 +2,18 @@
 
 import sys
 import os
-import numpy as np
 from datetime import date
+
+import numpy as np
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from MusculoskeletalAnalysisCLITools.crop import crop
-from MusculoskeletalAnalysisCLITools.writeReport import writeReport
-from MusculoskeletalAnalysisCLITools.density import densityMap
-import MusculoskeletalAnalysisCLITools.reader as reader
+from MusculoskeletalAnalysisCLITools import (
+  crop,
+  densityMap,
+  readImg,
+  readMask,
+  writeReport,
+)
 
 
 OUTPUT_FIELDS = [
@@ -37,8 +42,8 @@ OUTPUT_FIELDS = [
 # slope, intercept and scale: parameters of the equation for converting image values to mgHA/ccm
 # output: The name of the output directory
 def main(inputImg, inputMask, voxSize, slope, intercept, name, output):
-    imgData=reader.readImg(inputImg)
-    (_, maskData) = reader.readMask(inputMask)
+    imgData = readImg(inputImg)
+    (_, maskData) = readMask(inputMask)
     (maskData, imgData) = crop(maskData, imgData)
     if np.count_nonzero(maskData) == 0:
          raise Exception("Segmentation mask is empty.")

--- a/CLI/IntervertebralAnalysis/IntervertebralAnalysis.py
+++ b/CLI/IntervertebralAnalysis/IntervertebralAnalysis.py
@@ -10,6 +10,21 @@ from MusculoskeletalAnalysisCLITools.writeReport import writeReport
 import MusculoskeletalAnalysisCLITools.reader as reader
 from MusculoskeletalAnalysisCLITools.width import width
 
+
+OUTPUT_FIELDS = [
+    ("Date Analysis Performed", "The current date"),
+    ("Input Volume", "Name of the input volume"),
+    ("Disc Volume (mm^3)", "The volume of the disc"),
+    ("Nucleus Pulposus Volume (mm^3)", "The volume of the NP"),
+    ("Volume Ratio", "The ratio of whole disc volume to NP volume"),
+    ("Annulus Fibrosus Width (mm)", "The width of the AF, calculated by using rotating calipers algorithm on each slice and finding the maximum width"),
+    ("Nucleus Pulposus Width (mm)", "The width of the NP, calculated using the same method as AF width"),
+    ("Disc Height (mm)", "The height of the disc at its center"),
+    ("Disc Height Ratio", "The ratio of disc height to disc width"),
+    ("Voxel Dimension (mm)", "The side length of one voxel, measured in milimeters"),
+]
+
+
 def main(inputImg, inputMask1, inputMask2, voxSize, name, output):   
     imgData=reader.readImg(inputImg)
     (_, maskData1) = reader.readMask(inputMask1)
@@ -45,18 +60,7 @@ def main(inputImg, inputMask1, inputMask2, voxSize, name, output):
     sys.stdout.flush()
 
     fPath = os.path.join(output, "intervertebral.txt")
-    header = [
-        'Date Analysis Performed',
-        'Input Volume',
-        'Disc Volume (mm^3)',
-        'Nucleus Pulposus Volume (mm^3)',
-        'Volume Ratio',
-        'Annulus Fibrosus Width (mm)',
-        'Nucleus Pulposus Width (mm)',
-        'Disc Height (mm)',
-        'Disc Height Ratio',
-        'Voxel Dimension (mm)'
-    ]
+    header = [field[0] for field in OUTPUT_FIELDS]
     data = [
         date.today(),
         name,

--- a/CLI/IntervertebralAnalysis/IntervertebralAnalysis.py
+++ b/CLI/IntervertebralAnalysis/IntervertebralAnalysis.py
@@ -2,13 +2,18 @@
 
 import sys
 import os
-import numpy as np
 from datetime import date
+
+import numpy as np
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from MusculoskeletalAnalysisCLITools.crop import crop
-from MusculoskeletalAnalysisCLITools.writeReport import writeReport
-import MusculoskeletalAnalysisCLITools.reader as reader
-from MusculoskeletalAnalysisCLITools.width import width
+from MusculoskeletalAnalysisCLITools import (
+   crop,
+   readImg,
+   readMask,
+   width,
+   writeReport,
+)
 
 
 OUTPUT_FIELDS = [
@@ -26,9 +31,9 @@ OUTPUT_FIELDS = [
 
 
 def main(inputImg, inputMask1, inputMask2, voxSize, name, output):   
-    imgData=reader.readImg(inputImg)
-    (_, maskData1) = reader.readMask(inputMask1)
-    (_, maskData2) = reader.readMask(inputMask2)
+    imgData = readImg(inputImg)
+    (_, maskData1) = readMask(inputMask1)
+    (_, maskData2) = readMask(inputMask2)
     # Set the np mask to the smaller one
     if np.count_nonzero(maskData1) > np.count_nonzero(maskData2):
         (maskData, npData, imgData) = crop(maskData1, maskData2, imgData)

--- a/CLI/MusculoskeletalAnalysisCLITools/__init__.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/__init__.py
@@ -6,5 +6,6 @@ __all__ = [
     "reader",
     "shape",
     "thickness",
+    "width",
     "writeReport",
 ]

--- a/CLI/MusculoskeletalAnalysisCLITools/__init__.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/__init__.py
@@ -1,1 +1,10 @@
-__all__ = ['fill', 'thickness', 'writeReport', 'reader', 'crop', 'largestCC', 'shape', 'density']
+__all__ = [
+    "crop",
+    "density",
+    "fill",
+    "largestCC",
+    "reader",
+    "shape",
+    "thickness",
+    "writeReport",
+]

--- a/CLI/MusculoskeletalAnalysisCLITools/__init__.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/__init__.py
@@ -1,11 +1,25 @@
+from .crop import crop
+from .density import densityMap
+from .fill import fill
+from .largestCC import largestCC
+from .reader import readImg
+from .reader import readMask
+from .shape import bWshape
+from .shape import updateVertices
+from .thickness import findSpheres
+from .width import width
+from .writeReport import writeReport
+
 __all__ = [
     "crop",
-    "density",
+    "densityMap",
     "fill",
     "largestCC",
-    "reader",
-    "shape",
-    "thickness",
+    "readImg",
+    "readMask",
+    "bWshape",
+    "updateVertices",
+    "findSpheres",
     "width",
     "writeReport",
 ]

--- a/CLI/MusculoskeletalAnalysisCLITools/crop.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/crop.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-# Crops a series of ndarrays to the range of nonzero values in the first array for each dimension
+
 def crop(*args):
+    """Crops a series of ndarrays to the range of nonzero values in the first array for each dimension."""
     template = args[0]
     # Get the coodinates of all nonzero points in the first input as a tuple of arrays
     coords = np.nonzero(template)

--- a/CLI/MusculoskeletalAnalysisCLITools/density.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/density.py
@@ -1,4 +1,8 @@
-# Converts an image to a density map the same shape and size
-# Uses parameters from DICOM metadata to find linear relationship between pixel value and physical density
+
+
 def densityMap(img, slope, intercept):
+    """Converts an image to a density map the same shape and size.
+
+    Uses parameters from DICOM metadata to find linear relationship between pixel value and physical density.
+    """
     return img * slope + intercept

--- a/CLI/MusculoskeletalAnalysisCLITools/fill.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/fill.py
@@ -1,10 +1,10 @@
-import skimage.morphology
-import numpy as np
-
 # Takes a 2D binary numpy array and an integer radius
 # Performs morphological close with the given radius, then fills any holes not connected to the outer edge
 # Returns the transformed array
 def fill(mask, radius):
+
+    import numpy as np
+    import skimage.morphology
 
     # Performs morphological close, filling small gaps
     strel = skimage.morphology.disk(radius, dtype='bool')

--- a/CLI/MusculoskeletalAnalysisCLITools/fill.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/fill.py
@@ -1,8 +1,12 @@
-# Takes a 2D binary numpy array and an integer radius
-# Performs morphological close with the given radius, then fills any holes not connected to the outer edge
-# Returns the transformed array
-def fill(mask, radius):
 
+
+def fill(mask, radius):
+    """Performs morphological close with the given radius, then fills any holes not connected to the outer edge.
+
+    Takes a 2D binary numpy array and an integer radius.
+
+    Returns the transformed array.
+    """
     import numpy as np
     import skimage.morphology
 

--- a/CLI/MusculoskeletalAnalysisCLITools/largestCC.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/largestCC.py
@@ -1,10 +1,11 @@
-import numpy as np
-from skimage.measure import label
-
 # Takes a binary numpy array
 # Finds the largest connected component 
 # Returns the mask with only the largest component
 def largestCC(mask):
+
+    import numpy as np
+    from skimage.measure import label
+
     # Creates a labelmap of the mask, where connected components have the same label
     labels = label(mask)
     # labels[np.nonzero(labels)] is a list of all nonzero values in the labelmap. np.argmax(np.bincount()) returns the most common number in that list. largest is set to a mask showing where the labelmap is equal to that value.

--- a/CLI/MusculoskeletalAnalysisCLITools/largestCC.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/largestCC.py
@@ -1,8 +1,11 @@
-# Takes a binary numpy array
-# Finds the largest connected component 
-# Returns the mask with only the largest component
-def largestCC(mask):
 
+def largestCC(mask):
+    """Finds the largest connected component.
+
+    Takes a binary numpy array.
+
+    Returns the mask with only the largest component
+    """
     import numpy as np
     from skimage.measure import label
 

--- a/CLI/MusculoskeletalAnalysisCLITools/reader.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/reader.py
@@ -1,8 +1,8 @@
-# Converts slicer image and segmentation volumes into numpy format
+"""Converts slicer image and segmentation volumes into numpy format."""
 
-# readImg
-# Reads an image file as input, returns the image as a numpy array     
+
 def readImg(inputImg):   
+    """Reads an image file as input, returns the image as a numpy array."""
     import SimpleITK as sitk
 
     imgReader = sitk.ImageFileReader()
@@ -12,9 +12,9 @@ def readImg(inputImg):
     imgData = sitk.GetArrayFromImage(image)
     return imgData
 
-# readMask
-# Reads an nrrd file as input, returns the image as a binary numpy array
+
 def readMask(inputMask):
+    """Reads an nrrd file as input, returns the image as a binary numpy array."""
     from nrrd import read
 
     maskReader = read(inputMask)

--- a/CLI/MusculoskeletalAnalysisCLITools/reader.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/reader.py
@@ -1,12 +1,10 @@
-import SimpleITK as sitk
-from nrrd import read
-
-
 # Converts slicer image and segmentation volumes into numpy format
 
 # readImg
 # Reads an image file as input, returns the image as a numpy array     
 def readImg(inputImg):   
+    import SimpleITK as sitk
+
     imgReader = sitk.ImageFileReader()
     imgReader.SetFileName(inputImg)
     image = imgReader.Execute()
@@ -17,6 +15,8 @@ def readImg(inputImg):
 # readMask
 # Reads an nrrd file as input, returns the image as a binary numpy array
 def readMask(inputMask):
+    from nrrd import read
+
     maskReader = read(inputMask)
     maskHeader = maskReader[1:]
     maskData = maskReader[0].astype('bool')

--- a/CLI/MusculoskeletalAnalysisCLITools/shape.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/shape.py
@@ -1,7 +1,7 @@
 
 
-# Creates a triangular mesh shape using marching cubes algorithm 
 def bWshape(shape):
+    """Creates a triangular mesh shape using marching cubes algorithm."""
     from skimage import measure
     from trimesh import base
 
@@ -9,8 +9,9 @@ def bWshape(shape):
     mesh=base.Trimesh(vertices=verts, faces=face, vertex_normals=normals, validate=True)
     return mesh
 
-# Creates a mesh using a previous mesh's faces with new vertices locations
+
 def updateVertices(mesh, newVert):
+    """Creates a mesh using a previous mesh's faces with new vertices locations."""
     from trimesh import base
 
     mesh = base.Trimesh(vertices=newVert, faces=mesh.faces, vertex_normals=mesh.vertex_normals, validate=True)

--- a/CLI/MusculoskeletalAnalysisCLITools/shape.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/shape.py
@@ -1,13 +1,17 @@
-from skimage import measure
-from trimesh import base
+
 
 # Creates a triangular mesh shape using marching cubes algorithm 
 def bWshape(shape):
+    from skimage import measure
+    from trimesh import base
+
     verts, face, normals, values = measure.marching_cubes(shape)
     mesh=base.Trimesh(vertices=verts, faces=face, vertex_normals=normals, validate=True)
     return mesh
 
 # Creates a mesh using a previous mesh's faces with new vertices locations
 def updateVertices(mesh, newVert):
+    from trimesh import base
+
     mesh = base.Trimesh(vertices=newVert, faces=mesh.faces, vertex_normals=mesh.vertex_normals, validate=True)
     return mesh

--- a/CLI/MusculoskeletalAnalysisCLITools/thickness.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/thickness.py
@@ -1,6 +1,7 @@
-# Calculates thickness by finding the largest sphere containing each point
+
 
 def findSpheres(mask):
+    """Calculates thickness by finding the largest sphere containing each point."""
     import numpy as np
     from math import ceil
     from scipy.ndimage import distance_transform_edt

--- a/CLI/MusculoskeletalAnalysisCLITools/thickness.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/thickness.py
@@ -1,10 +1,10 @@
-from scipy.ndimage import distance_transform_edt
-import numpy as np
-from math import ceil
-
 # Calculates thickness by finding the largest sphere containing each point
 
 def findSpheres(mask):
+    import numpy as np
+    from math import ceil
+    from scipy.ndimage import distance_transform_edt
+
     dist = distance_transform_edt(mask)
     rads = dist.copy()
 

--- a/CLI/MusculoskeletalAnalysisCLITools/width.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/width.py
@@ -1,7 +1,5 @@
 # Calculates the width of a 2d shape using rotating calipers method
-import math
-from scipy.ndimage import convolve
-import numpy as np
+
 
 def crossProduct(a,b,c):
     return ((b[0]-a[0])*(c[1]-a[1]) - (b[1]-a[1])*(c[0]-a[0]))
@@ -26,6 +24,8 @@ def convexHull(pts):
     return hull[:-1]
 
 def rotatingCaliper(pts):
+    import math
+
     hull = convexHull(pts)
     n = len(hull)
 
@@ -50,6 +50,9 @@ def rotatingCaliper(pts):
     return res
 
 def edge(img):
+    import numpy as np
+    from scipy.ndimage import convolve
+
     filt = [[0,-1,0],
               [-1,4,-1],
               [0,-1,0]]

--- a/CLI/MusculoskeletalAnalysisCLITools/width.py
+++ b/CLI/MusculoskeletalAnalysisCLITools/width.py
@@ -1,12 +1,15 @@
-# Calculates the width of a 2d shape using rotating calipers method
+"""Calculates the width of a 2d shape using rotating calipers method."""
 
 
 def crossProduct(a,b,c):
     return ((b[0]-a[0])*(c[1]-a[1]) - (b[1]-a[1])*(c[0]-a[0]))
 
-# Finds the points on the convex hull
-# Prereq: The points must be sorted left to right and top to bottom
+
 def convexHull(pts):
+    """Finds the points on the convex hull.
+
+    Prereq: The points must be sorted left to right and top to bottom
+    """
 
     hull = []
     n = len(pts)
@@ -22,6 +25,7 @@ def convexHull(pts):
         hull.append(p)
     # Exclude the last point because it is same as the first
     return hull[:-1]
+
 
 def rotatingCaliper(pts):
     import math
@@ -49,6 +53,7 @@ def rotatingCaliper(pts):
  
     return res
 
+
 def edge(img):
     import numpy as np
     from scipy.ndimage import convolve
@@ -60,6 +65,7 @@ def edge(img):
 
 
 def width(mask):
+    """Calculates the width of a 2d shape using rotating calipers method."""
     n = mask.shape[2]
     maxw = 0
     for i in range(n):

--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ The program requires information from certain DICOM tags to run. Normally it can
 The output file is a`tsv` file named `cortical.txt` with the following columns:
 
 * **Date Analysis Performed**: The current date
-* **File ID**: The output filepath
-* **Mean Cortical Thickness**: The mean thickness of the bone, measured by largest sphere thickness, in milimeters.
-* **Cortical Thickness Standard Deviation**: The standard deviation of the above measurement.
-* **Tissue Mineral Density**: The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter
+* **Input Volume**: Name of the input volume
+* **Mean Cortical Thickness (mm)**: The mean thickness of the bone, measured by largest sphere thickness, in milimeters
+* **Cortical Thickness Standard Deviation (mm)**: The standard deviation of the above measurement
+* **Tissue Mineral Density(mgHA/cm^3)**: The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter
 * **Porosity**: The fraction of the bone area made up of pores
-* **Total Area**: The area of the bone and medullary cavity. All areas are measured in average square milimeters per slice
-* **Bone Area**: The area of the bone
-* **Medullary Area**: The area of the medullary cavity
-* **Polar Moment of Interia**: The moment of intertia around the z-axis, based on the shape of the mask. Measured in mm^4
-* **Voxel Dimension**: The side length of one voxel, measured in milimeters
+* **Total Area (mm^2)**: The area of the bone and medullary cavity. All areas are measured in average square milimeters per slice
+* **Bone Area (mm^2)**: The area of the bone
+* **Medullary Area (mm^2)**: The area of the medullary cavity
+* **Polar Moment of Interia(mm^4)**: The moment of intertia around the z-axis, based on the shape of the mask. Measured in mm^4
+* **Voxel Dimension (mm)**: The side length of one voxel, measured in milimeters
 
 ## Cancellous Analysis
 
@@ -69,19 +69,19 @@ The output file is a`tsv` file named `cortical.txt` with the following columns:
 The output file is a`tsv` file named `cancellous.txt` with the following columns:
 
 * **Date Analysis Performed**: The current date
-* **File ID**: The output filepath
-* **Total Volume**: The volume of the segmented area
-* **Bone Volume**: The volume of cancellous bone in the segmented area, calculated using marching cubes
+* **Input Volume**: Name of the input volume
+* **Total Volume (mm^3)**: The volume of the segmented area
+* **Bone Volume (mm^3)**: The volume of cancellous bone in the segmented area, calculated using marching cubes
 * **Bone Volume/Total Volume**: The fraction of the volume that is bone
-* **Mean Trabecular Thickness**: The mean thickess of the bone, measured using largest sphere thickness, in milimeters
-* **Trabecular Thickness Standard Deviation**: The standard deviation of the above mean
-* **Mean Trabecular Spacing**: The mean thickness of the non area not containing bone in milimeters, measured using the same method as bone thickness.
-* **Trabecular Spacing Standard Deviation**: The standard deviation of the above mean
+* **Mean Trabecular Thickness (mm)**: The mean thickess of the bone, measured using largest sphere thickness, in milimeters
+* **Trabecular Thickness Standard Deviation (mm)**: The standard deviation of the mean trabecular thickness
+* **Mean Trabecular Spacing (mm)**: The mean thickness of the non area not containing bone in milimeters, measured using the same method as bone thickness.
+* **Trabecular Spacing Standard Deviation (mm)**: The standard deviation of the mean trabecular spacing
 * **Trabecular Number**: Approximated as inverse of trabecular spacing
-* **Structural Model Index**: A measurement of the trabecular shape. 0 is a plate, 3 is a rod, 4 is a sphere
+* **Structure Model Index**: A measurement of the trabecular shape. 0 is a plate, 3 is a rod, 4 is a sphere
 * **Connectivity Density**: A measurement of the number of connections per volume, based on the Euler characteristic of the bone after removing isolated components and holes
-* **Tissue Mineral Density**: The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter
-* **Voxel Dimension**: The side length of one voxel, measured in milimeters
+* **Tissue Mineral Density(mgHA/cm^3)**: The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter
+* **Voxel Dimension (mm)**: The side length of one voxel, measured in milimeters
 * **Lower Threshold**: The lower threshold value for bone
 * **Upper Threshold**: The upper threshold value for bone
 
@@ -98,7 +98,7 @@ The output file is a`tsv` file named `cancellous.txt` with the following columns
 The output file is a`tsv` file named `density.txt`.
 
 * **Date Analysis Performed**: The current date
-* **File ID**: The output filepath
+* **Input Volume**: Name of the input volume
 * **Area by Slice**: The area of the segment in each slice of each slice
 * **Mean Density by Slice**: The average density of the segmented area each slice
 * **Standard Deviation of Density by Slice**: The standard deviation of the density of each slice
@@ -126,15 +126,15 @@ The output file is a`tsv` file named `density.txt`.
 The output file is a`tsv` file named `intervertebral.txt` with the following columns:
 
 * **Date Analysis Performed**: The current date
-* **File ID**: The output filepath
-* **Disc Volume**: The volume of the disc
-* **Nucleus Pulposus Volume**: The volume of the NP
+* **Input Volume**: Name of the input volume
+* **Disc Volume (mm^3)**: The volume of the disc
+* **Nucleus Pulposus Volume (mm^3)**: The volume of the NP
 * **Volume Ratio**: The ratio of whole disc volume to NP volume
-* **Annulus Fibrosus Width**: The width of the AF, calculated by using rotating calipers algorithm on each slice and finding the maximum width
-* **Nucleus Pulposus Width**: The width of the NP, calculated using the same method as above
-* **Disc Height**: The height of the disc at its center
+* **Annulus Fibrosus Width (mm)**: The width of the AF, calculated by using rotating calipers algorithm on each slice and finding the maximum width
+* **Nucleus Pulposus Width (mm)**: The width of the NP, calculated using the same method as AF width
+* **Disc Height (mm)**: The height of the disc at its center
 * **Disc Height Ratio**: The ratio of disc height to disc width
-* **Voxel Dimension**: The side length of one voxel, measured in milimeters
+* **Voxel Dimension (mm)**: The side length of one voxel, measured in milimeters
 
 ## Python Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,114 +1,159 @@
 # Slicer-MusculoskeletalAnalysis
-Musculoskeletal Analysis extension for 3D Slicer. Currently Alpha
 
-![Alt text](/Scripted/MusculoskeletalAnalysis/Resources/Icons/Screenshot.png?raw=true)
+Musculoskeletal Analysis extension for 3D Slicer.
 
-## Dependencies
-The following additional python packages are required:<br/>
-pynrrd: All analysis<br/>
-scikit-image: Cortical Analysis and Cancellous Analysis<br/>
-scipy: Cortical Analysis and Cancellous Analysis<br/>
-trimesh: Cancellous Analysis
-
-Packages will be installed when the associated analysis functions are run.
-
+<p align="center">
+  <img width="50%" src="Scripted/MusculoskeletalAnalysis/Resources/Icons/MusculoskeletalAnalysis.png" alt="MusculoskeletalAnalysis Logo"/>
+</p>
 
 ## How to use
-1. Load a DICOM 3D image using the Add DICOM Data module.
+
+1. Load a DICOM 3D image using the _Add DICOM Data_ module.
 2. Create a segment representing the area to analyze using the Segmentations and Segment Editor modules. See the input parameters of the function for more details on what to include in the segment.
-3. Select which type of analysis you wish to perform.
+3. Open the _Musculoskeletal Analysis_ module and select which type of analysis you wish to perform.
 4. Use the Threshold Selector to select the values for bone. Used to seperate bone from pores in cortical analysis and spacing in cancellous analysis.
 5. (Optional) Use the Advanced tab if the volume is not loaded from a DICOM.
 6. Use the Output Directory Selector to select a directory. Output files will be created in this directory if they do not already exist, or will be appended to if they do.
 
-## Advanced tab
+## Musculoskeletal Analysis
+
+### IO: Input/output parameters
+
+* **Input Volume**: A 3d image of the bone.
+* **Analysis Segment**: A segment of the image containing the bone area to analyse.
+* **Threshold**: Threshold values representing bone.
+* **Analysis**: Select the analysis to perform.
+* **Output Directory**: The location to save the output file to.
+
+### Advanced tab
+
 The program requires information from certain DICOM tags to run. Normally it can retrieve that information from the volume node, but if the volume node does not have those tags(i.e, if you are using a copy of the original volume, or your data came from a different format), you can either select a node that does, or enter the values manually.
 
-
 ## Cortical Analysis
-### Input Parameters:
-Input Volume: A 3d image of the bone.
-Bone Segment: A segment of the image containing the cortical bone area. Includes pores, excludes the medullary cavity.
-Threshold: Threshold values representing bone. Used to seperate bone from pores.
-Output Directory: The location to save the output file to. File will be a tsv file named cortical.txt. 
 
-### Output Parameters:
-Date Analysis Performed: The current date
-File ID: The output filepath
-Mean Cortical Thickness: The mean thickness of the bone, measured by largest sphere thickness, in milimeters.
-Cortical Thickness Standard Deviation: The standard deviation of the above measurement.
-Tissue Mineral Density: The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter
-Porosity: The fraction of the bone area made up of pores
-Total Area: The area of the bone and medullary cavity. All areas are measured in average square milimeters per slice
-Bone Area: The area of the bone
-Medullary Area: The area of the medullary cavity
-Polar Moment of Interia: The moment of intertia around the z-axis, based on the shape of the mask. Measured in mm^4
-Voxel Dimension: The side length of one voxel, measured in milimeters
+### IO: Input/output parameters
 
+* **Input Volume**: A 3d image of the bone.
+* **Bone Segment**: A segment of the image containing the cortical bone area. Includes pores, excludes the medullary cavity.
+* **Threshold**: Threshold values representing bone. Used to seperate bone from pores.
+* **Output Directory**: The location to save the output file to.
+
+### Output File
+
+The output file is a`tsv` file named `cortical.txt` with the following columns:
+
+* **Date Analysis Performed**: The current date
+* **File ID**: The output filepath
+* **Mean Cortical Thickness**: The mean thickness of the bone, measured by largest sphere thickness, in milimeters.
+* **Cortical Thickness Standard Deviation**: The standard deviation of the above measurement.
+* **Tissue Mineral Density**: The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter
+* **Porosity**: The fraction of the bone area made up of pores
+* **Total Area**: The area of the bone and medullary cavity. All areas are measured in average square milimeters per slice
+* **Bone Area**: The area of the bone
+* **Medullary Area**: The area of the medullary cavity
+* **Polar Moment of Interia**: The moment of intertia around the z-axis, based on the shape of the mask. Measured in mm^4
+* **Voxel Dimension**: The side length of one voxel, measured in milimeters
 
 ## Cancellous Analysis
-### Input Parameters:
-Input Volume: A 3d image of the bone.
-Bone Segment: A segment of the image containing the cancellous bone area. Includes the medullary cavity, excludes surrounding cotical bone.
-Threshold: Threshold values representing bone. Used to seperate bone from cavity.
-Output Directory: The location to save the output file to. File will be a tsv file named cancellous.txt.
+
+### IO: Input/output parameters
+
+* **Input Volume:** A 3d image of the bone.
+* **Bone Segment:** A segment of the image containing the cancellous bone area. Includes the medullary cavity, excludes surrounding cotical bone.
+* **Threshold:** Threshold values representing bone. Used to seperate bone from cavity.
+* **Output Directory:** The location to save the output file to.
 
 
-### Output Parameters:
-Date Analysis Performed: The current date
-File ID: The output filepath
-Total Volume: The volume of the segmented area
-Bone Volume: The volume of cancellous bone in the segmented area, calculated using marching cubes
-Bone Volume/Total Volume: The fraction of the volume that is bone
-Mean Trabecular Thickness: The mean thickess of the bone, measured using largest sphere thickness, in milimeters
-Trabecular Thickness Standard Deviation: The standard deviation of the above mean
-Mean Trabecular Spacing: The mean thickness of the non area not containing bone in milimeters, measured using the same method as bone thickness.
-Trabecular Spacing Standard Deviation: The standard deviation of the above mean
-Trabecular Number: Approximated as inverse of trabecular spacing
-Structural Model Index: A measurement of the trabecular shape. 0 is a plate, 3 is a rod, 4 is a sphere
-Connectivity Density: A measurement of the number of connections per volume, based on the Euler characteristic of the bone after removing isolated components and holes
-Tissue Mineral Density: The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter
-Voxel Dimension: The side length of one voxel, measured in milimeters
-Lower Threshold: The lower threshold value for bone
-Upper Threshold: The upper threshold value for bone
+### Output File
+
+The output file is a`tsv` file named `cancellous.txt` with the following columns:
+
+* **Date Analysis Performed**: The current date
+* **File ID**: The output filepath
+* **Total Volume**: The volume of the segmented area
+* **Bone Volume**: The volume of cancellous bone in the segmented area, calculated using marching cubes
+* **Bone Volume/Total Volume**: The fraction of the volume that is bone
+* **Mean Trabecular Thickness**: The mean thickess of the bone, measured using largest sphere thickness, in milimeters
+* **Trabecular Thickness Standard Deviation**: The standard deviation of the above mean
+* **Mean Trabecular Spacing**: The mean thickness of the non area not containing bone in milimeters, measured using the same method as bone thickness.
+* **Trabecular Spacing Standard Deviation**: The standard deviation of the above mean
+* **Trabecular Number**: Approximated as inverse of trabecular spacing
+* **Structural Model Index**: A measurement of the trabecular shape. 0 is a plate, 3 is a rod, 4 is a sphere
+* **Connectivity Density**: A measurement of the number of connections per volume, based on the Euler characteristic of the bone after removing isolated components and holes
+* **Tissue Mineral Density**: The mean density of the bone, measured in miligrams of hydroxyapatite per cubic centimeter
+* **Voxel Dimension**: The side length of one voxel, measured in milimeters
+* **Lower Threshold**: The lower threshold value for bone
+* **Upper Threshold**: The upper threshold value for bone
 
 ## Density Analysis
-### Input Parameters:
-Input Volume: A 3d image of the bone.
-Bone Segment: A segmentation of the image containing the bone area to be measured.
-Output Directory: The location to save the output file to. File will be a tsv file named density.txt.
 
-### Output Parameters:
-Date Analysis Performed: The current date
-File ID: The output filepath
-Area by Slice: The area of the segment in each slice of each slice
-Mean Density by Slice: The average density of the segmented area each slice
-Standard Deviation of Density by Slice: The standard deviation of the density of each slice
-Min Density by Slice: The lowest density in the segment of each slice
-Max Density by Slice: The highest density in the segment of each slice
-Mean Area: The mean area of the segment of all slices
-Standard Deviation of Area: The standard deviation of the segmented area of all slices
-Min Area: The area of the smallest segment slice
-Max Area: The area of the largest segment slice
-Mean Density: The average density of the entire segmented volume
-Standard Deviation of Density: The standard deviation of density of the segmented volume
-Min Density: The minimum density of the segmented volume
-Max Density: The maximum density of the segmented volume
+### IO: Input/output parameters
+
+* **Input Volume**: A 3d image of the bone.
+* **Bone Segment**: A segmentation of the image containing the bone area to be measured.
+* **Output Directory**: The location to save the output file to.
+
+### Output File
+
+The output file is a`tsv` file named `density.txt`.
+
+* **Date Analysis Performed**: The current date
+* **File ID**: The output filepath
+* **Area by Slice**: The area of the segment in each slice of each slice
+* **Mean Density by Slice**: The average density of the segmented area each slice
+* **Standard Deviation of Density by Slice**: The standard deviation of the density of each slice
+* **Min Density by Slice**: The lowest density in the segment of each slice
+* **Max Density by Slice**: The highest density in the segment of each slice
+* **Mean Area**: The mean area of the segment of all slices
+* **Standard Deviation of Area**: The standard deviation of the segmented area of all slices
+* **Min Area**: The area of the smallest segment slice
+* **Max Area**: The area of the largest segment slice
+* **Mean Density**: The average density of the entire segmented volume
+* **Standard Deviation of Density**: The standard deviation of density of the segmented volume
+* **Min Density**: The minimum density of the segmented volume
+* **Max Density**: The maximum density of the segmented volume
 
 ## Intervertebral Analysis
-### Input Parameters:
-Input Volume: A 3d image of an intervertebral disc
-Segement1, Segment2: Two segmentations containing the disc and the nucleus pulposus. (Differentiated by size)
-Output Directory: The location to save the output file to. File will be a tsv file named intervertebral.txt.
 
-### Output Parameters:
-Date Analysis Performed: The current date
-File ID: The output filepath
-Disc Volume: The volume of the disc
-Nucleus Pulposus Volume: The volume of the NP
-Volume Ratio: The ratio of whole disc volume to NP volume
-Annulus Fibrosus Width: The width of the AF, calculated by using rotating calipers algorithm on each slice and finding the maximum width
-Nucleus Pulposus Width: The width of the NP, calculated using the same method as above
-Disc Height: The height of the disc at its center
-Disc Height Ratio: The ratio of disc height to disc width
-Voxel Dimension: The side length of one voxel, measured in milimeters
+### IO: Input/output parameters
+
+* **Input Volume**: A 3d image of an intervertebral disc
+* **Segement1** and **Segment2**: Two segmentations containing the disc and the nucleus pulposus. (Differentiated by size)
+* **Output Directory**: The location to save the output file to.
+
+### Output File
+
+The output file is a`tsv` file named `intervertebral.txt` with the following columns:
+
+* **Date Analysis Performed**: The current date
+* **File ID**: The output filepath
+* **Disc Volume**: The volume of the disc
+* **Nucleus Pulposus Volume**: The volume of the NP
+* **Volume Ratio**: The ratio of whole disc volume to NP volume
+* **Annulus Fibrosus Width**: The width of the AF, calculated by using rotating calipers algorithm on each slice and finding the maximum width
+* **Nucleus Pulposus Width**: The width of the NP, calculated using the same method as above
+* **Disc Height**: The height of the disc at its center
+* **Disc Height Ratio**: The ratio of disc height to disc width
+* **Voxel Dimension**: The side length of one voxel, measured in milimeters
+
+## Python Dependencies
+
+The following additional python packages are required and will be installed the corresponding analysis functions are run:
+
+|                | Cortical Analysis  | Cancellous Analysis | Density Analysis   | Intervertebral Analysis |
+|----------------|--------------------|---------------------|--------------------|-------------------------|
+| `pynrrd`       | :white_check_mark: | :white_check_mark:  | :white_check_mark: | :white_check_mark:      |
+| `scikit-image` | :white_check_mark: | :white_check_mark:  |                    |                         |
+| `scipy`        | :white_check_mark: | :white_check_mark:  |                    |                         |
+| `trimesh`      |                    | :white_check_mark:  |                    |                         |
+
+## Screenshots
+
+| ![Musculoskeletal Analysis](Scripted/MusculoskeletalAnalysis/Resources/Icons/Screenshot.png) |
+|--|
+| <sub>_User interface of the Musculoskeletal Analysis module._</sub> |
+
+## License
+
+This software is licensed under the terms of the [MIT](LICENSE.txt).
+

--- a/Scripted/MusculoskeletalAnalysis/MusculoskeletalAnalysis.py
+++ b/Scripted/MusculoskeletalAnalysis/MusculoskeletalAnalysis.py
@@ -22,7 +22,12 @@ class MusculoskeletalAnalysis(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Musculoskeletal Analysis"
         self.parent.categories = ["Analysis"]  # TODO: set categories (folders where the module shows up in the module selector)
-        self.parent.dependencies = ["CorticalAnalysis", "CancellousAnalysis", "DensityAnalysis"]  # TODO: add here list of module names that this module requires
+        self.parent.dependencies = [
+            "CorticalAnalysis",
+            "CancellousAnalysis",
+            "DensityAnalysis",
+            "IntervertebralAnalysis",
+        ]
         self.parent.contributors = ["Joseph Szatkowski (Washington University in St. Louis)"]
         # TODO: update with short description of the module and a link to online module documentation
         self.parent.helpText = """


### PR DESCRIPTION
### Summary

* Re-organize and fix formatting of `README`
* Ensure `IntervertebralAnalysis` Scripted CLI and `MusculoskeletalAnalysisCLITools.width` python module are distributed
* Refactor CLI to document output fields alongside their usage
* Re-generate markdown list in "Output File" section

### Convenience snippet for generating `Output File` documentation

```python
import os
import sys

import MusculoskeletalAnalysis

# To support importing CLIs
sys.path.insert(0, os.path.join(os.path.dirname(MusculoskeletalAnalysis.__file__), "../cli-modules"))


from CancellousAnalysis import OUTPUT_FIELDS as CancellousAnalysisOutputFields
from CorticalAnalysis import OUTPUT_FIELDS as CorticalAnalysisOutputFields
from DensityAnalysis import OUTPUT_FIELDS as DensityAnalysisOutputFields
from IntervertebralAnalysis import OUTPUT_FIELDS as IntervertebralAnalysisOutputFields


def generateOutputFileFieldsDocumentation(output_fields):
    for name, description in output_fields:
        print(f"* **{name}**: {description}")


print("\nCancellousAnalysisOutputFields")
generateOutputFileFieldsDocumentation(CancellousAnalysisOutputFields)

print("\nCorticalAnalysisOutputFields")
generateOutputFileFieldsDocumentation(CorticalAnalysisOutputFields)

print("\nDensityAnalysisOutputFields")
generateOutputFileFieldsDocumentation(DensityAnalysisOutputFields)

print("\nIntervertebralAnalysisOutputFields")
generateOutputFileFieldsDocumentation(IntervertebralAnalysisOutputFields)
```

### Preview of README changes

| Before | After |
|--|--|
| ![image](https://github.com/WashUMusculoskeletalCore/Slicer-MusculoskeletalAnalysis/assets/219043/77a5d836-7532-4d3a-95eb-75255486e040) | ![image](https://github.com/WashUMusculoskeletalCore/Slicer-MusculoskeletalAnalysis/assets/219043/95e5fb2b-bd34-43c0-992f-bbd94e2c61ec) |

